### PR TITLE
feat: add doap project description to version control as suggested by the ASF

### DIFF
--- a/docs/static/doap_PouchDB.rdf
+++ b/docs/static/doap_PouchDB.rdf
@@ -1,0 +1,60 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl"?>
+<rdf:RDF xml:lang="en"
+         xmlns="http://usefulinc.com/ns/doap#" 
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" 
+         xmlns:asfext="http://projects.apache.org/ns/asfext#"
+         xmlns:foaf="http://xmlns.com/foaf/0.1/">
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+   
+         https://www.apache.org/licenses/LICENSE-2.0
+   
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+  <Project rdf:about="https://pouchdb.apache.org">
+    <created>2026-07-01</created>
+    <license rdf:resource="https://spdx.org/licenses/Apache-2.0" />
+    <name>Apache PouchDB</name>
+    <homepage rdf:resource="https://pouchdb.apache.org" />
+    <asfext:pmc rdf:resource="https://incubator.apache.org" />
+    <shortdesc>Apache PouchDB is an open-source JavaScript database inspired by Apache CouchDB that is designed to run well within the browser.</shortdesc>
+    <description>PouchDB is an open-source JavaScript database inspired by Apache CouchDB that is designed to run well within the browser.
+
+PouchDB was created to help web developers build applications that work as well offline as they do online.
+
+It enables applications to store data locally while offline, then synchronize it with CouchDB and compatible servers when the application is back online, keeping the user's data in sync no matter where they next log in.</description>
+    <bug-database rdf:resource="https://github.com/apache/pouchdb/issues" />
+    <mailing-list rdf:resource="https://lists.apache.org/list.html?dev@pouchdb.apache.org" />
+    <download-page rdf:resource="https://pouchdb.apache.org/download.html" />
+    <programming-language>JavaScript</programming-language>
+    <category rdf:resource="https://projects.apache.org/category/content" />
+    <category rdf:resource="https://projects.apache.org/category/database" />
+    <category rdf:resource="https://projects.apache.org/category/http" />
+    <category rdf:resource="https://projects.apache.org/category/mobile" />
+    <category rdf:resource="https://projects.apache.org/category/network-client" />
+    <release>
+      <Version>
+        <name>Apache PouchDB </name>
+        <created>2024-05-24</created>
+        <revision>9.0.0</revision>
+      </Version>
+    </release>
+    <repository>
+      <GitRepository>
+        <location rdf:resource="https://github.com/apache/pouchdb"/>
+        <browse rdf:resource="https://github.com/apache/pouchdb"/>
+      </GitRepository>
+    </repository>
+  </Project>
+</rdf:RDF>
+


### PR DESCRIPTION
## Overview

This PR adds a [DOAP file](https://projects.apache.org/create.html). It describes our project in ASF terms, and the file will eventually be consumed by some service at the ASF that displays PouchDB in the ASF projects feed.

> [!IMPORTANT]
> This file is up for discussion in this PR, once it is merged, it must be added to the projects feed file by one of us

The file will be publicly available at https://pouchdb.apache.org/static/doap_PouchDB.rdf

This is part of the [fulfill other ASF requirements issue](https://github.com/apache/pouchdb/issues/9259).

## Testing recommendations

The file comes straight out of the ASF DOAP generator, so it should be valid out of the box. If we make manual changes: [Validate the file](https://www.w3.org/RDF/Validator/) and check it against the [guidelines](https://projects.apache.org/guidelines.html). 

## Related Issues or Pull Requests

Part of #9259 

## Checklist

- [x] I am not a bot
- [x] This is my own work, I did not use AI, LLM's or similar technology for code or docs generation

